### PR TITLE
feat: 小红书图导出（大字报首图 + 自动分割内容图）

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+# 小红书图 / 首图底部的品牌名（开发模式下生效，改这里即可）。
+# 不配也行——代码里默认就是 FiilyAiLabs。
+VITE_BRAND=FiilyAiLabs

--- a/src/components/MobileActionsMenu.vue
+++ b/src/components/MobileActionsMenu.vue
@@ -11,6 +11,7 @@ const emit = defineEmits<{
   'copy-html': []
   'save-image': []
   'copy-rich-text': []
+  'export-xhs': []
   'go-components': []
 }>()
 
@@ -178,6 +179,25 @@ onBeforeUnmount(() => {
             <path d="M21 15l-5-5L5 21" />
           </svg>
           保存图片
+        </button>
+        <button
+          class="mobile-action-option w-full flex items-center gap-2 px-3 py-2 rounded-lg border-none bg-transparent cursor-pointer text-[13px] text-black/80 transition-colors duration-150 hover:bg-black/5"
+          @click="handleAction(() => emit('export-xhs'))"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            width="14"
+            height="14"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <rect x="4" y="2" width="16" height="20" rx="2" />
+            <path d="M8 7h8M8 11h8M8 15h5" />
+          </svg>
+          小红书图
         </button>
         <button
           class="mobile-action-option w-full flex items-center gap-2 px-3 py-2 rounded-lg border-none bg-transparent cursor-pointer text-[13px] text-black/80 transition-colors duration-150 hover:bg-black/5"

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -105,6 +105,18 @@ async function saveAsImage() {
       skipFonts: true,
       cacheBust: true,
       backgroundColor: '#ffffff',
+      // 文章里有加载不出来的图（404、本地相对路径被 dev server 当 index.html 返回、跨域等）时，
+      // 用透明占位顶上、并跳过出错的图，而不是让整张导出失败抛出 [object Event]
+      imagePlaceholder:
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+      onImageErrorHandler: (e: Event | string) => {
+        if (typeof e === 'string') return
+        const t = e.target as HTMLImageElement | null
+        if (t && 'src' in t) {
+          t.src =
+            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='
+        }
+      },
       style: {
         padding: '20px 16px 40px',
       },
@@ -125,7 +137,12 @@ async function saveAsImage() {
     link.click()
     showToast('✅ 图片已保存')
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg =
+      err instanceof Error
+        ? err.message
+        : typeof Event !== 'undefined' && err instanceof Event
+          ? '渲染失败（可能有图片加载不出来）'
+          : String(err)
     showToast('❌ 生成失败：' + msg)
   } finally {
     saving.value = false

--- a/src/components/XhsExporter.vue
+++ b/src/components/XhsExporter.vue
@@ -1,0 +1,488 @@
+<script setup lang="ts">
+import { ref, watch, nextTick } from 'vue'
+import { toPng } from 'html-to-image'
+import { parseMarkdown } from '../utils/markdownParser'
+import type { ThemeColors } from '../composables/useTheme'
+import {
+  extractXhs,
+  buildCover,
+  ASPECTS,
+  PIXEL_RATIO,
+  FONT_STACK,
+  CONTENT_SCALE,
+  XHS,
+  type XhsAspect,
+} from '../utils/xhsCards'
+
+// 图片加载失败时的占位（透明 1px），避免一张坏图把整次渲染拖崩
+const TRANSPARENT_PX =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='
+
+// html-to-image 失败常常抛的是一个 Event（图片加载错误），直接 String() 会变 [object Event]
+function errText(e: unknown): string {
+  if (e instanceof Error) return e.message
+  if (typeof Event !== 'undefined' && e instanceof Event) return '渲染失败（可能有图片加载不出来）'
+  return String(e)
+}
+
+// 图片加载失败（含 dev server 把缺图当 index.html 返回、跨域等）时不让整张渲染崩，
+// 把这张图换成透明占位，渲染照常进行，缺图位置留白。
+function onImgError(e: Event | string) {
+  if (typeof e === 'string') return
+  const t = e.target as HTMLImageElement | null
+  if (t && 'src' in t) t.src = TRANSPARENT_PX
+}
+
+// 小节标题块：原生 #~#### 渲染成 H1~H4；<p-title> 渲染成带 data-block="ptitle" 的 section
+function isHeadingBlock(el: HTMLElement): boolean {
+  return /^H[1-6]$/.test(el.tagName) || el.dataset?.block === 'ptitle'
+}
+
+const props = defineProps<{
+  visible: boolean
+  markdown: string
+  colors: ThemeColors
+}>()
+
+defineEmits<{ close: [] }>()
+
+interface Card {
+  id: string
+  label: string
+  kind: 'html' | 'image'
+  html?: string // 首图：HTML，导出时 toPng
+  src?: string // 内容图：已经切好的 PNG dataURL
+}
+
+const aspect = ref<XhsAspect>('3:4')
+const cards = ref<Card[]>([])
+const building = ref(false)
+const busy = ref(false)
+const status = ref('')
+
+// 首图卡的外层 DOM（导出时读它第一个子元素，即卡片 section）
+let cardEls: (HTMLElement | null)[] = []
+function setRef(el: Element | null, idx: number) {
+  cardEls[idx] = el as HTMLElement | null
+}
+
+/** 等容器里图片都加载完（带 4s 兜底），否则渲染会拿到错的高度。 */
+function waitImages(el: HTMLElement): Promise<void> {
+  const imgs = Array.from(el.querySelectorAll('img'))
+  if (!imgs.length) return Promise.resolve()
+  return new Promise((resolve) => {
+    let done = 0
+    const tick = () => {
+      done += 1
+      if (done >= imgs.length) resolve()
+    }
+    setTimeout(resolve, 4000)
+    imgs.forEach((img) => {
+      if (img.complete) tick()
+      else {
+        img.onload = tick
+        img.onerror = tick
+      }
+    })
+  })
+}
+
+/**
+ * 内容图：和「保存图片」一样把正文渲染出来，但用一个卡片大小的取景窗，
+ * 每次把正文上移一屏、单独导出一张（每张都小、稳，不会因整篇太长或坏图崩掉）。
+ * 底部留一条 DOM 页脚带（@品牌 + 页码），盖住被切断的半行。
+ */
+async function renderSlices(contentHtml: string, brand: string, colors: ThemeColors): Promise<string[]> {
+  // 在「放大的逻辑画布」上渲染正文：边距/页脚等比放大、正文字号不变 → 输出（仍 1080 宽）
+  // 里正文相对更小、更密，而边距和页脚跟首图保持一致。
+  const base = ASPECTS[aspect.value]
+  const NATIVE_W = base.w * PIXEL_RATIO // 输出宽度（1080）
+  // 关键：用「实时预览」的内容宽度当基准，让内容图和「保存图片」共用同一套排版比例
+  // （字号、换行、左右边距都一致）。CONTENT_SCALE 是在此基础上的密度倍数（1 = 完全对齐）。
+  const previewInner = document.querySelector('.phone-frame > div') as HTMLElement | null
+  const refW = previewInner && previewInner.clientWidth > 80 ? previewInner.clientWidth : 450
+  const w = Math.round(refW * CONTENT_SCALE)
+  const h = Math.round((w * base.h) / base.w) // 保持比例（3:4 / 1:1）
+  const ratio = NATIVE_W / w // 缩放到 1080 宽输出
+  // 正文与「保存图片」一致：白底 + 同样的左右/上边距 + 同样的基础字号/行距。
+  const bg = '#ffffff'
+  const padX = 16 // 对齐「保存图片」的左右边距
+  const padTop = 20 // 对齐「保存图片」的上边距
+  const footerBand = 44
+  const fBrand = 14
+  const fPage = 13
+  const dash = '1.5'
+
+  // 隐藏器：0×0 + overflow 裁切，把取景窗藏起来但保留布局尺寸。
+  // 注意不能用 position:fixed;left:-99999px 来藏取景窗——那样在 html-to-image 生成的
+  // SVG foreignObject 里会被定位到画布外，导出就是空白。取景窗本身必须是 relative。
+  const hider = document.createElement('div')
+  hider.style.cssText = 'position:fixed;left:0;top:0;width:0;height:0;overflow:hidden;z-index:-1'
+
+  // 取景窗：定宽定高 + overflow 裁切（relative，作为内部绝对定位正文的包含块）
+  const frame = document.createElement('div')
+  frame.style.cssText =
+    `position:relative;width:${w}px;height:${h}px;overflow:hidden;` +
+    `box-sizing:border-box;background:${bg};font-family:${FONT_STACK}`
+
+  // 正文层：绝对定位，靠改 top 往上滚
+  const wrap = document.createElement('div')
+  // 基础字号/行距/颜色对齐 Preview 的 previewRef（15px / 1.8 / #333），
+  // 这样列表、零散文本等没单独设字号的内容也跟「保存图片」一致。
+  wrap.style.cssText =
+    `position:absolute;left:0;top:0;width:${w}px;box-sizing:border-box;` +
+    `padding:${padTop}px ${padX}px 0;font-size:15px;line-height:1.8;color:rgb(51,51,51)`
+  wrap.innerHTML = contentHtml
+
+  // 页脚带：整条不透明底色，盖住正文被切断处；内部虚线 + @品牌 + 页码
+  const footer = document.createElement('div')
+  footer.style.cssText =
+    `position:absolute;left:0;right:0;bottom:0;height:${footerBand}px;background:${bg};` +
+    `box-sizing:border-box;padding:0 ${padX}px;z-index:2`
+  const inner = document.createElement('div')
+  inner.style.cssText =
+    `height:100%;display:flex;align-items:center;justify-content:space-between;` +
+    `border-top:${dash}px dashed ${XHS.dash}`
+  const brandEl = document.createElement('span')
+  brandEl.style.cssText = `font-size:${fBrand}px;color:${colors.dark};font-weight:800`
+  brandEl.textContent = '@' + brand
+  const pageEl = document.createElement('span')
+  pageEl.style.cssText = `font-size:${fPage}px;color:${XHS.inkFaint};font-weight:800;letter-spacing:0.5px`
+  inner.append(brandEl, pageEl)
+  footer.append(inner)
+
+  frame.append(wrap, footer)
+  hider.appendChild(frame)
+  document.body.appendChild(hider)
+  await waitImages(frame)
+
+  // 按「块」分页：parseMarkdown 把每段 / 标题 / 引用 / 图片都包成顶层块。
+  // 每页放整数个块、块绝不跨页；把不属于本页的块设成 visibility:hidden
+  // （占位不变、偏移稳定，但不显示），这样下一块不会从底部露出来 → 不切断、不重复、不丢。
+  const topInset = padTop // 每页顶部留白
+  const budget = h - footerBand - topInset // 每页可用正文高度（页脚以上、扣掉顶部留白）
+  const blocks = Array.from(wrap.children) as HTMLElement[]
+
+  // 把块连续切成若干页 [startIdx, endIdx)
+  const pages: { startIdx: number; endIdx: number; top: number }[] = []
+  let k = 0
+  while (k < blocks.length) {
+    const pageTop = blocks[k].offsetTop
+    let j = k
+    while (j < blocks.length) {
+      const bottom = blocks[j].offsetTop + blocks[j].offsetHeight
+      // j 放不下且本页已有块 → 收尾；本页第一个块再高也先放进来（避免死循环）
+      if (j > k && bottom - pageTop > budget) break
+      j++
+    }
+    // 孤儿标题：本页最后一个块是小节标题、且本页不止它一个 → 让标题跟着正文挪到下一页
+    while (j - k > 1 && isHeadingBlock(blocks[j - 1])) j--
+    pages.push({ startIdx: k, endIdx: j, top: pageTop })
+    k = j
+  }
+  if (!pages.length) pages.push({ startIdx: 0, endIdx: 0, top: 0 })
+
+  const n = pages.length
+  const slices: string[] = []
+  try {
+    for (let i = 0; i < n; i++) {
+      const { startIdx, endIdx, top } = pages[i]
+      blocks.forEach((b, idx) => {
+        b.style.visibility = idx >= startIdx && idx < endIdx ? 'visible' : 'hidden'
+      })
+      wrap.style.top = `${topInset - top}px`
+      pageEl.textContent = `${i + 1} / ${n}`
+      slices.push(
+        await toPng(frame, {
+          pixelRatio: ratio,
+          width: w,
+          height: h,
+          backgroundColor: bg,
+          skipFonts: true,
+          imagePlaceholder: TRANSPARENT_PX,
+          onImageErrorHandler: onImgError,
+        }),
+      )
+    }
+  } finally {
+    document.body.removeChild(hider)
+  }
+  return slices
+}
+
+async function generate() {
+  building.value = true
+  status.value = ''
+  try {
+    const { meta, contentMd } = extractXhs(props.markdown)
+    const cover: Card = {
+      id: 'cover',
+      label: '首图（大字报）',
+      kind: 'html',
+      html: buildCover(meta, aspect.value, props.colors),
+    }
+    const contentHtml = parseMarkdown(contentMd, props.colors)
+    const slices = contentHtml.trim() ? await renderSlices(contentHtml, meta.brand, props.colors) : []
+
+    cardEls = []
+    cards.value = [
+      cover,
+      ...slices.map((src, i) => ({
+        id: 'p' + i,
+        label: `内容 ${i + 1}`,
+        kind: 'image' as const,
+        src,
+      })),
+    ]
+    await nextTick()
+  } catch (e) {
+    status.value = '生成失败：' + errText(e)
+  } finally {
+    building.value = false
+  }
+}
+
+async function cardDataUrl(idx: number): Promise<string> {
+  const card = cards.value[idx]
+  if (card.kind === 'image') return card.src as string
+  const node = cardEls[idx]?.firstElementChild as HTMLElement | undefined
+  if (!node) throw new Error('卡片节点丢失')
+  const { w, h } = ASPECTS[aspect.value]
+  return toPng(node, {
+    pixelRatio: PIXEL_RATIO,
+    width: w,
+    height: h,
+    backgroundColor: XHS.bg,
+    skipFonts: true,
+    imagePlaceholder: TRANSPARENT_PX,
+    onImageErrorHandler: onImgError,
+  })
+}
+
+function fileName(idx: number): string {
+  const date = new Date().toISOString().slice(0, 10)
+  const tag = idx === 0 ? '00_cover' : String(idx).padStart(2, '0')
+  return `xhs_${date}_${tag}.png`
+}
+
+function triggerDownload(dataUrl: string, name: string) {
+  const a = document.createElement('a')
+  a.download = name
+  a.href = dataUrl
+  a.click()
+}
+
+async function downloadOne(idx: number) {
+  if (busy.value) return
+  busy.value = true
+  try {
+    triggerDownload(await cardDataUrl(idx), fileName(idx))
+  } catch (e) {
+    status.value = '导出失败：' + errText(e)
+  } finally {
+    busy.value = false
+  }
+}
+
+async function downloadAll() {
+  if (busy.value || !cards.value.length) return
+  busy.value = true
+  try {
+    for (let i = 0; i < cards.value.length; i++) {
+      status.value = `导出中 ${i + 1}/${cards.value.length}…`
+      triggerDownload(await cardDataUrl(i), fileName(i))
+      await new Promise((r) => setTimeout(r, 180))
+    }
+    status.value = `已导出 ${cards.value.length} 张`
+  } catch (e) {
+    status.value = '导出失败：' + errText(e)
+  } finally {
+    busy.value = false
+  }
+}
+
+function setAspect(a: XhsAspect) {
+  if (aspect.value === a) return
+  aspect.value = a
+  if (props.visible) generate()
+}
+
+watch(
+  () => props.visible,
+  (v) => {
+    if (v) generate()
+  },
+)
+</script>
+
+<template>
+  <div v-if="visible" class="xhs-overlay" @click.self="$emit('close')">
+    <div class="xhs-panel">
+      <header class="xhs-head">
+        <strong class="xhs-title">导出小红书图</strong>
+        <div class="xhs-aspect">
+          <button :class="{ on: aspect === '3:4' }" @click="setAspect('3:4')">3:4 竖版</button>
+          <button :class="{ on: aspect === '1:1' }" @click="setAspect('1:1')">1:1 方版</button>
+        </div>
+        <span class="xhs-status">{{ status }}</span>
+        <button class="xhs-btn primary" :disabled="busy || building || !cards.length" @click="downloadAll">
+          下载全部（{{ cards.length }}）
+        </button>
+        <button class="xhs-close" @click="$emit('close')">✕</button>
+      </header>
+
+      <div class="xhs-body">
+        <p v-if="building" class="xhs-hint">生成中…</p>
+        <div class="xhs-grid">
+          <div v-for="(c, idx) in cards" :key="c.id" class="xhs-item">
+            <div
+              v-if="c.kind === 'html'"
+              class="xhs-frame"
+              :ref="(el) => setRef(el as Element | null, idx)"
+              v-html="c.html"
+            ></div>
+            <img v-else class="xhs-frame xhs-img" :src="c.src" alt="" />
+            <div class="xhs-item-bar">
+              <span class="xhs-label">{{ c.label }}</span>
+              <button class="xhs-btn" :disabled="busy" @click="downloadOne(idx)">下载</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.xhs-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(20, 18, 15, 0.55);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.xhs-panel {
+  width: 100%;
+  max-width: 960px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.3);
+}
+.xhs-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid #eee;
+  flex-shrink: 0;
+}
+.xhs-title {
+  font-size: 15px;
+  color: #1f1a17;
+}
+.xhs-aspect {
+  display: flex;
+  gap: 4px;
+  background: #f3f0ea;
+  border-radius: 999px;
+  padding: 3px;
+}
+.xhs-aspect button {
+  border: none;
+  background: transparent;
+  padding: 5px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #8a8175;
+  cursor: pointer;
+}
+.xhs-aspect button.on {
+  background: #f39c12;
+  color: #fff;
+}
+.xhs-status {
+  flex: 1;
+  font-size: 12px;
+  color: #a89a86;
+  text-align: right;
+}
+.xhs-btn {
+  border: 1px solid #f39c12;
+  background: #fff;
+  color: #e67e22;
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.xhs-btn.primary {
+  background: #f39c12;
+  color: #fff;
+}
+.xhs-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.xhs-close {
+  border: none;
+  background: transparent;
+  font-size: 16px;
+  color: #999;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+.xhs-body {
+  overflow: auto;
+  padding: 20px;
+  background: #f6f5f2;
+}
+.xhs-hint {
+  text-align: center;
+  color: #999;
+  font-size: 13px;
+  padding: 20px;
+}
+.xhs-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  justify-content: center;
+}
+.xhs-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.xhs-frame {
+  width: 360px;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+  line-height: 0;
+}
+.xhs-img {
+  display: block;
+  height: auto;
+}
+.xhs-item-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.xhs-label {
+  font-size: 12px;
+  color: #8a8175;
+  font-weight: 600;
+}
+</style>

--- a/src/utils/markdownParser.ts
+++ b/src/utils/markdownParser.ts
@@ -273,7 +273,8 @@ export function parseMarkdown(md: string, t: ThemeColors): string {
       if (ptMatch) {
         const attrs = parseAttrs(ptMatch[1])
         const body = ptMatch[2].trim()
-        html += PTitle.render(attrs, body, t)
+        // 给根节点打个标记（不影响样式），分页时用它避免小节标题落在页底跟正文分家
+        html += PTitle.render(attrs, body, t).replace('<section', '<section data-block="ptitle"')
       }
       i++
       continue

--- a/src/utils/xhsCards.ts
+++ b/src/utils/xhsCards.ts
@@ -1,0 +1,265 @@
+/**
+ * 小红书图卡生成
+ *
+ * 把一篇 markdown 拆成：一张「大字报」首图 + 若干张自动分页的内容卡。
+ * 风格统一到公众号配图：暖米底 + 橙色主题 + 暖黑 + 圆角胶囊徽章 + 黑色高亮条 +
+ * 虚线圆角框 + 手写感橙色波浪下划线 + 小星点。
+ *
+ * 本模块只产出 HTML 字符串（纯函数）。真正按高度自动分页的测量逻辑在
+ * components/XhsExporter.vue 里——那一步需要 DOM。
+ */
+import type { ThemeColors } from '../composables/useTheme'
+import { esc, parseAttrs } from './helpers'
+
+// ── 设计令牌（对齐公众号配图）──
+// 注意：强调色（accent）不写死，跟随 r-markdown 当前主题色（buildCover/内容图都用传入的 ThemeColors）。
+export const XHS = {
+  bg: '#F7F2E8', // 暖米底，纸感
+  card: '#FFFDF8', // 卡片上更亮的米白
+  ink: '#1F1A17', // 暖黑（标题）
+  inkSoft: '#5C5346', // 暖灰（正文）
+  inkFaint: '#A89A86', // 更浅（元信息）
+  dash: '#D9C9AC', // 虚线边色
+}
+
+export type XhsAspect = '3:4' | '1:1'
+
+export const ASPECTS: Record<XhsAspect, { w: number; h: number }> = {
+  '3:4': { w: 360, h: 480 },
+  '1:1': { w: 360, h: 360 },
+}
+
+// 逻辑尺寸 360 宽，导出时 ×3 → 1080 宽（小红书原生尺寸）。
+export const PIXEL_RATIO = 3
+export const PAD_X = 30
+export const PAD_TOP = 32
+export const PAD_BOTTOM = 24
+// 内容图底部页脚带的高度（逻辑像素），切片时给它留出空间。
+export const FOOTER_BAND = 46
+
+export const FONT_STACK = `-apple-system,BlinkMacSystemFont,'PingFang SC','Microsoft YaHei',sans-serif`
+
+// 内容图密度旋钮：内容图默认按「实时预览的宽度」渲染，从而和「保存图片」完全同一套
+// 排版比例（字号、换行、左右边距都对齐）。这个值是在预览宽度基础上的额外倍数：
+//   1   = 和「保存图片」完全一致；
+//   >1  = 用更宽的画布渲染 → 同一张图里字更小、一行更多字 → 更密（但会和保存图片略有出入）。
+export const CONTENT_SCALE = 1
+
+// 底部品牌名默认值：优先读环境变量 VITE_BRAND（在 .env / .env.development 里配），否则 FiilyAiLabs。
+export const DEFAULT_BRAND: string =
+  (import.meta.env?.VITE_BRAND as string | undefined) || 'FiilyAiLabs'
+
+export interface XhsMeta {
+  title: string
+  badge: string
+  summary: string
+  teaser: string
+  hook: string
+  chips: string[]
+  brand: string
+  charCount: number
+  readMin: number
+}
+
+/** 去掉行内修饰符号，给摘要取纯文本用。 */
+function stripInline(s: string): string {
+  return s
+    .replace(/<[^>]+>/g, '')
+    .replace(/\[\[([^\]]+)\]\]/g, '$1')
+    .replace(/[=^!~`*_]/g, '')
+    .replace(/::/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** 抽正文里能当导语用的纯文本段落（跳过标题/标签/列表/引用/代码），拼到够长为止。 */
+function bodyPreview(md: string, limit = 320): string {
+  const out: string[] = []
+  let total = 0
+  for (const raw of md.split('\n')) {
+    const t = raw.trim()
+    if (!t || /^[#>\-*+:<`|!]/.test(t) || /^---+$/.test(t) || /^\d+\.\s/.test(t)) continue
+    const text = stripInline(t)
+    if (!text) continue
+    out.push(text)
+    total += text.length
+    if (total >= limit) break
+  }
+  return out.join(' ')
+}
+
+/**
+ * 从 markdown 抽出首图素材 + 去掉头部后的正文。
+ * 支持两种头部写法：YAML frontmatter（--- ... ---）和 <title ...>标题</title> 标签。
+ */
+export function extractXhs(md: string): { meta: XhsMeta; contentMd: string } {
+  const meta: XhsMeta = {
+    title: '',
+    badge: '',
+    summary: '',
+    teaser: '',
+    hook: '',
+    chips: [],
+    brand: DEFAULT_BRAND,
+    charCount: 0,
+    readMin: 1,
+  }
+  let contentMd = md
+  const lines = md.split('\n')
+
+  if (lines[0] && lines[0].trim() === '---') {
+    let i = 1
+    const fm: Record<string, string> = {}
+    while (i < lines.length && lines[i].trim() !== '---') {
+      const m = lines[i].match(/^(\w+):\s*(.+)/)
+      if (m) fm[m[1]] = m[2].trim()
+      i++
+    }
+    contentMd = lines.slice(i + 1).join('\n')
+    meta.title = fm.title || ''
+    meta.badge = fm.badge || ''
+    meta.summary = fm.summary || fm.subtitle || ''
+    meta.hook = fm.hook || ''
+    meta.brand = fm.brand || fm.author || meta.brand
+    meta.chips = (fm.chips || '').split('|').map((c) => c.trim()).filter(Boolean)
+  } else {
+    const tm = md.match(/<title\b([^>]*)>([\s\S]*?)<\/title>/)
+    if (tm) {
+      const attrs = parseAttrs(tm[1])
+      meta.title = (attrs.title || tm[2] || '').trim()
+      meta.badge = attrs.badge || ''
+      meta.summary = attrs.summary || attrs.subtitle || ''
+      meta.hook = attrs.hook || ''
+      meta.brand = attrs.brand || meta.brand
+      meta.chips = (attrs.chips || '').split('|').map((c) => c.trim()).filter(Boolean)
+      // 不剥掉 <title>：它既喂给大字报首图，也保留在正文里照常渲染成标题卡
+    }
+  }
+
+  // 摘要兜底：frontmatter 没给，就抓第一个 <lead> 或第一段正文
+  if (!meta.summary) {
+    const lead = contentMd.match(/<lead\b[^>]*>([\s\S]*?)<\/lead>/)
+    if (lead) {
+      meta.summary = stripInline(lead[1])
+    } else {
+      for (const l of contentMd.split('\n')) {
+        const t = l.trim()
+        if (!t || /^[#>\-*+:<`|!]/.test(t) || /^---+$/.test(t)) continue
+        meta.summary = stripInline(t)
+        break
+      }
+    }
+  }
+
+  // 首图用的「摘要」：以摘要/副标题打头，接上正文开头，凑长一点，末尾让它渐隐掉。
+  const body = bodyPreview(contentMd)
+  if (!meta.summary) {
+    meta.teaser = body
+  } else if (body && !body.startsWith(meta.summary)) {
+    meta.teaser = meta.summary + ' ' + body
+  } else {
+    meta.teaser = body || meta.summary
+  }
+  meta.teaser = meta.teaser.slice(0, 300)
+
+  // 字数 / 阅读时长（沿用 renderFrontMatter 的口径）
+  const clean = md
+    .replace(/---[\s\S]*?---\s*/, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/[#*`>[\]!|_~=^:-]/g, '')
+    .replace(/\s+/g, '')
+  meta.charCount = clean.length
+  meta.readMin = Math.max(1, Math.ceil(meta.charCount / 400))
+
+  return { meta, contentMd }
+}
+
+// ── 装饰件 ──
+
+/** 手写感波浪下划线（标题下方），颜色用主题色。 */
+function swoosh(width: number, accent: string): string {
+  const w = width
+  return `<svg width="${w}" height="14" viewBox="0 0 ${w} 14" fill="none" xmlns="http://www.w3.org/2000/svg" style="display:block"><path d="M2 9 C ${w * 0.2} 2, ${w * 0.4} 13, ${w * 0.6} 7 S ${w * 0.85} 2, ${w - 3} 8" stroke="${accent}" stroke-width="4" stroke-linecap="round"/></svg>`
+}
+
+/** 四角星点（主题色）。 */
+function star(size: number, accent: string): string {
+  return `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="${accent}" xmlns="http://www.w3.org/2000/svg" style="display:block"><path d="M12 0 C13 7 17 11 24 12 C17 13 13 17 12 24 C11 17 7 13 0 12 C7 11 11 7 12 0Z"/></svg>`
+}
+
+/** 标题里用 ==xx== 标记的部分渲染成主题色，其余暖黑。 */
+function titleHtml(title: string, accent: string): string {
+  const parts = title.split(/(==[^=]+==)/)
+  let out = ''
+  for (const p of parts) {
+    if (!p) continue
+    const m = p.match(/^==([^=]+)==$/)
+    if (m) out += `<span style="color:${accent}">${esc(m[1])}</span>`
+    else out += `<span style="color:${XHS.ink}">${esc(p)}</span>`
+  }
+  return out
+}
+
+function chipsHtml(chips: string[], t: ThemeColors): string {
+  if (!chips.length) return ''
+  let html = `<section style="margin:0px;font-size:0px;line-height:1.9">`
+  chips.forEach((c) => {
+    html += `<span style="display:inline-block;margin:0px 8px 0px 0px;padding:3px 12px;border-radius:999px;border:1.5px solid ${t.border};background:${t.light};font-size:12px;font-weight:700;color:${t.dark};white-space:nowrap">${esc('#' + c)}</span>`
+  })
+  html += `</section>`
+  return html
+}
+
+/**
+ * 大字报首图（flex 纵向铺满）。
+ * 结构：橙色徽章 → 大标题(==橙==+暖黑) + 波浪线 → 摘要(撑满、末尾渐隐) →
+ * 可选黑色高亮条 → 话题标签 → 页脚(字数·分钟 + 品牌)。右上 / 左下点缀星点。
+ */
+export function buildCover(meta: XhsMeta, aspect: XhsAspect, t: ThemeColors): string {
+  const { w, h } = ASPECTS[aspect]
+  const contentW = w - PAD_X * 2
+
+  let html = `<section style="position:relative;box-sizing:border-box;width:${w}px;height:${h}px;background:${XHS.bg};padding:${PAD_TOP}px ${PAD_X}px ${PAD_BOTTOM}px;overflow:hidden;display:flex;flex-direction:column;font-family:-apple-system,BlinkMacSystemFont,'PingFang SC','Microsoft YaHei',sans-serif">`
+
+  // 角标星点
+  html += `<section style="position:absolute;top:20px;right:24px">${star(22, t.accent)}</section>`
+  html += `<section style="position:absolute;bottom:74px;left:16px;opacity:0.75">${star(13, t.accent)}</section>`
+
+  // 徽章（line-height + nowrap 确保圆角把 Day N 整个包住）
+  if (meta.badge) {
+    html += `<section style="flex-shrink:0;margin:0px 0px 16px"><span style="display:inline-block;padding:6px 16px;border-radius:11px;background:${t.accent};color:#fff;font-size:15px;font-weight:800;line-height:1.3;letter-spacing:0.5px;white-space:nowrap;box-shadow:0 4px 12px ${t.accent}55">${esc(meta.badge)}</span></section>`
+  }
+
+  // 标题 + 波浪线
+  html += `<h1 style="flex-shrink:0;margin:0px;font-size:34px;line-height:1.18;font-weight:900;letter-spacing:-0.5px;word-break:break-word">${titleHtml(meta.title, t.accent)}</h1>`
+  html += `<section style="flex-shrink:0;margin:8px 0px 14px">${swoosh(Math.min(contentW, 220), t.accent)}</section>`
+
+  // 摘要：占满中间剩余空间，超出部分用底部渐变淡出（到最后消失）
+  const teaser = meta.teaser || meta.summary
+  if (teaser) {
+    html += `<section style="position:relative;flex:1 1 auto;min-height:0;overflow:hidden;margin:0px 0px 14px">`
+    html += `<p style="margin:0px;font-size:15.5px;line-height:1.75;color:${XHS.inkSoft};font-weight:500">${esc(teaser)}</p>`
+    html += `<section style="position:absolute;left:0px;right:0px;bottom:0px;height:56px;background:linear-gradient(to bottom,rgba(247,242,232,0),${XHS.bg})"></section>`
+    html += `</section>`
+  }
+
+  // 黑色高亮条（可选 hook）
+  if (meta.hook) {
+    html += `<section style="flex-shrink:0;margin:0px 0px 12px"><span style="display:inline-block;padding:8px 16px;border-radius:12px;background:${XHS.ink};color:#fff;font-size:15px;font-weight:800;line-height:1.45">${esc(meta.hook)}</span></section>`
+  }
+
+  // 话题标签
+  if (meta.chips.length) {
+    html += `<section style="flex-shrink:0;margin:0px 0px 14px">${chipsHtml(meta.chips, t)}</section>`
+  }
+
+  // 页脚：字数 / 阅读时长 + 品牌
+  html += `<section style="flex-shrink:0;display:flex;align-items:flex-end;justify-content:space-between;border-top:1.5px dashed ${XHS.dash};padding-top:12px">`
+  html += `<span style="font-size:12px;color:${XHS.inkFaint};font-weight:700;letter-spacing:0.3px">${esc('共 ' + meta.charCount + ' 字 · 约 ' + meta.readMin + ' 分钟')}</span>`
+  html += `<span style="font-size:13px;color:${t.dark};font-weight:800">${esc('@' + meta.brand)}</span>`
+  html += `</section>`
+
+  html += `</section>`
+  return html
+}
+

--- a/src/views/EditorPage.vue
+++ b/src/views/EditorPage.vue
@@ -8,6 +8,7 @@ import Preview from '../components/Preview.vue'
 import ThemePicker from '../components/ThemePicker.vue'
 import DarkModeToggle from '../components/DarkModeToggle.vue'
 import MobileActionsMenu from '../components/MobileActionsMenu.vue'
+import XhsExporter from '../components/XhsExporter.vue'
 
 const { accent, colors, setTheme, setCustomTheme, customColor, themes } = useTheme()
 const { mode: darkMode, isDark, setMode: setDarkMode } = useDarkMode()
@@ -74,6 +75,7 @@ const SAVE_TIME_KEY = 'wechat-md-editor-save-time'
 const saved = localStorage.getItem(STORAGE_KEY)
 const markdown = ref(saved !== null ? saved : DEMO_CONTENT)
 const previewRef = ref()
+const xhsVisible = ref(false)
 const savedTime = localStorage.getItem(SAVE_TIME_KEY)
 const saveHint = ref(savedTime ? '已保存 ' + savedTime : '')
 
@@ -323,6 +325,19 @@ onBeforeUnmount(() => {
           保存图片
         </button>
         <button
+          class="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 border-none rounded text-[13px] font-medium cursor-pointer transition-all duration-150 bg-[var(--accent-light)] text-[var(--accent)] hover:bg-[var(--accent)] hover:text-white active:scale-[0.97]"
+          @click="xhsVisible = true"
+        >
+          <svg
+            class="w-3.5 h-3.5 fill-none stroke-current stroke-2 stroke-linecap-round stroke-linejoin-round"
+            viewBox="0 0 24 24"
+          >
+            <rect x="4" y="2" width="16" height="20" rx="2" />
+            <path d="M8 7h8M8 11h8M8 15h5" />
+          </svg>
+          小红书图
+        </button>
+        <button
           class="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 border-none rounded text-[13px] font-medium cursor-pointer transition-all duration-150 bg-[var(--accent)] text-white hover:bg-[var(--accent-dark)] active:scale-[0.97]"
           @click="handleCopyRichText"
         >
@@ -342,6 +357,7 @@ onBeforeUnmount(() => {
           @copy-html="handleCopyHTML"
           @save-image="handleSaveImage"
           @copy-rich-text="handleCopyRichText"
+          @export-xhs="xhsVisible = true"
           @go-components="$router.push('/components')"
         />
         <ThemePicker
@@ -460,6 +476,13 @@ onBeforeUnmount(() => {
         <Preview ref="previewRef" :markdown="markdown" :colors="colors" />
       </div>
     </div>
+
+    <XhsExporter
+      :visible="xhsVisible"
+      :markdown="markdown"
+      :colors="colors"
+      @close="xhsVisible = false"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
## 这个 PR 做了什么

给编辑器加了一个「小红书图」导出：把一篇文章一键导成小红书图集。

- **大字报首图**：从 frontmatter（或 `<title>` 标签）抽取 标题 / 徽章 / 摘要 / 话题标签，渲成一张大字报封面，摘要末尾渐隐。强调色**跟随当前选中的主题色**。
- **自动分割内容图**：复用现有排版引擎渲染正文，再**按块自动分页** —— 段落 / 引用 / 图片整块不跨页，小节标题不会落在页底（自动顺到下一页）。与「保存图片」共用同一套宽度 / 字号 / 左右边距，两边视觉一致。
- 弹窗里可切 **3:4 / 1:1**，每张可单独下载或「下载全部」，输出 1080×1440 / 1080×1080。
- 顺带修了「保存图片」的一个健壮性问题：文章里有**加载不出来的图**（404、跨域、或 dev server 把缺图当 index.html 返回）时，原先会让整张导出失败（抛 `[object Event]`），现在改成跳过坏图、照常导出。
- 底部品牌名支持 `VITE_BRAND` 配置。

## 改动文件

- 新增 `src/utils/xhsCards.ts`（纯函数：素材抽取 + 卡片 HTML 构造）
- 新增 `src/components/XhsExporter.vue`（弹窗 + 按块分页 + 逐张导出）
- `src/views/EditorPage.vue` / `src/components/MobileActionsMenu.vue`：接入「小红书图」入口
- `src/utils/markdownParser.ts`：给 `<p-title>` 根节点加了个不可见标记（`data-block="ptitle"`，仅用于分页时识别小节标题，不影响样式）
- `src/components/Preview.vue`：给「保存图片」加图片错误兜底（`imagePlaceholder` + `onImageErrorHandler`）

## 用法

工具栏点「小红书图」→ 弹窗里预览图集 → 单张下载或一键全下。不改动现有任何功能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)