### PR TITLE
feat: add RTL/LTR direction formatting

### DIFF
--- a/src/utils/markdownParser.ts
+++ b/src/utils/markdownParser.ts
@@ -149,6 +149,24 @@ export interface ParagraphStyle {
   margin: number
 }
 
+type ContentDirection = 'ltr' | 'rtl'
+
+function normalizeDirection(value?: string): ContentDirection | null {
+  const dir = value?.trim().toLowerCase()
+  return dir === 'ltr' || dir === 'rtl' ? dir : null
+}
+
+function getDirection(attrs: Record<string, string>, allowValue = false): ContentDirection | null {
+  return normalizeDirection(attrs.dir || attrs.direction || (allowValue ? attrs.value : undefined))
+}
+
+function wrapDirection(html: string, attrs: Record<string, string>, allowValue = false): string {
+  const dir = getDirection(attrs, allowValue)
+  if (!dir) return html
+  const textAlign = dir === 'rtl' ? 'right' : 'left'
+  return `<section dir="${dir}" style="direction:${dir};text-align:${textAlign};unicode-bidi:plaintext">${html}</section>`
+}
+
 /**
  * 一步完成：收集公式 → 预渲染 → 解析。
  * 推荐所有 caller 使用这个入口。
@@ -212,6 +230,27 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
       continue
     }
 
+    // <direction dir="rtl|ltr"> ... </direction>
+    if (/^<direction\b/.test(line)) {
+      const openMatch = line.match(/^<direction\b([^>]*)>(.*)$/)
+      const attrs = openMatch && openMatch[1] ? parseAttrs(openMatch[1]) : {}
+      if (openMatch && openMatch[2] && /<\/direction>\s*$/.test(openMatch[2])) {
+        const body = openMatch[2].replace(/<\/direction>\s*$/, '').trim()
+        html += wrapDirection(parseMarkdown(body, t, formulaMap, paragraphStyle), attrs, true)
+        i++
+        continue
+      }
+      let body = openMatch && openMatch[2] ? openMatch[2] + '\n' : ''
+      i++
+      while (i < lines.length && !/^<\/direction>/.test(lines[i])) {
+        body += lines[i] + '\n'
+        i++
+      }
+      i++ // skip </direction>
+      html += wrapDirection(parseMarkdown(body.trim(), t, formulaMap, paragraphStyle), attrs, true)
+      continue
+    }
+
     // <steps>
     if (/^<steps\b/.test(line)) {
       const openMatch = line.match(/^<steps\b([^>]*)>/)
@@ -224,7 +263,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
       }
       i++ // skip </steps>
       const stepsRenderer = attrs.type === 'DA02' ? Steps_DA02 : Steps_DA01
-      html += stepsRenderer.render(attrs, body.trim(), t)
+      html += wrapDirection(stepsRenderer.render(attrs, body.trim(), t), attrs)
       continue
     }
     // <statement> ... </statement>
@@ -234,7 +273,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
       // 单行模式
       if (openMatch && openMatch[2] && /<\/statement>\s*$/.test(openMatch[2])) {
         const text = openMatch[2].replace(/<\/statement>\s*$/, '').trim()
-        html += Statement_DA01.render(attrs, text, t)
+        html += wrapDirection(Statement_DA01.render(attrs, text, t), attrs)
         i++
         continue
       }
@@ -246,7 +285,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         i++
       }
       i++
-      html += Statement_DA01.render(attrs, text.trim(), t)
+      html += wrapDirection(Statement_DA01.render(attrs, text.trim(), t), attrs)
       continue
     }
     // <badges> ... </badges> (支持单行和多行)
@@ -256,7 +295,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
       // 单行模式：<badges ...>content</badges>
       if (openMatch && openMatch[2] && /<\/badges>\s*$/.test(openMatch[2])) {
         const body = openMatch[2].replace(/<\/badges>\s*$/, '').trim()
-        html += Badges_DA01.render(attrs, body, t)
+        html += wrapDirection(Badges_DA01.render(attrs, body, t), attrs)
         i++
         continue
       }
@@ -268,7 +307,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         i++
       }
       i++ // skip </badges>
-      html += Badges_DA01.render(attrs, body.trim(), t)
+      html += wrapDirection(Badges_DA01.render(attrs, body.trim(), t), attrs)
       continue
     }
     // <lead> ... </lead>
@@ -278,7 +317,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
       // 单行模式
       if (openMatch && openMatch[2] && /<\/lead>\s*$/.test(openMatch[2])) {
         const text = openMatch[2].replace(/<\/lead>\s*$/, '').trim()
-        html += Lead_DA01.render(attrs, text, t)
+        html += wrapDirection(Lead_DA01.render(attrs, text, t), attrs)
         i++
         continue
       }
@@ -290,7 +329,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         i++
       }
       i++
-      html += Lead_DA01.render(attrs, text.trim(), t)
+      html += wrapDirection(Lead_DA01.render(attrs, text.trim(), t), attrs)
       continue
     }
     // <breaking>
@@ -304,15 +343,16 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         i++
       }
       i++ // skip </breaking>
-      html += Breaking_DA01.render(attrs, body.trim(), t)
+      html += wrapDirection(Breaking_DA01.render(attrs, body.trim(), t), attrs)
       continue
     }
     // <cta>
     if (/^<cta\b/.test(line)) {
+      const attrs = parseAttrs(line)
       if (/\/>\s*$/.test(line)) {
         // 自闭合行内形式：<cta .../>
         const r = parseCtaInline(lines, i, t)
-        html += r.html
+        html += wrapDirection(r.html, attrs)
         i = r.next
       } else {
         // 前窥后续是否存在 </cta> 关闭标签，有则走标签形式，否则按行内处理
@@ -325,11 +365,11 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         }
         if (hasClosingCta) {
           const r = parseCtaTag(lines, i, t)
-          html += r.html
+          html += wrapDirection(r.html, attrs)
           i = r.next
         } else {
           const r = parseCtaInline(lines, i, t)
-          html += r.html
+          html += wrapDirection(r.html, attrs)
           i = r.next
         }
       }
@@ -337,8 +377,9 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
     }
     // <compare>
     if (/^<compare\b/.test(line)) {
+      const attrs = parseAttrs(line)
       const r = parseCompare(lines, i, t)
-      html += r.html
+      html += wrapDirection(r.html, attrs)
       i = r.next
       continue
     }
@@ -347,7 +388,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
       const attrsStr = line.match(/^<reading-path\b([^>]*)>?/)?.[1] || ''
       const attrs = parseAttrs(attrsStr)
       const rendered = ReadingPath_DA01.render(attrs, pTitleLevel1List, t)
-      html += rendered
+      html += wrapDirection(rendered, attrs)
       // 跳过闭合标签（如果有）
       if (
         /^<reading-path>/.test(line) &&
@@ -368,9 +409,9 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         const body = titleMatch[2].trim()
         const type = (attrs.type || 'DA01').toUpperCase()
         if (type === 'DA02') {
-          html += Title_DA02.render(attrs, body, t, md)
+          html += wrapDirection(Title_DA02.render(attrs, body, t, md), attrs)
         } else {
-          html += Title_DA01.render(attrs, body, t, md)
+          html += wrapDirection(Title_DA01.render(attrs, body, t, md), attrs)
         }
       }
       i++
@@ -384,7 +425,8 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         const attrs = parseAttrs(ptMatch[1])
         const body = ptMatch[2].trim()
         // 给根节点打个标记（不影响样式），分页时用它避免小节标题落在页底跟正文分家
-        html += PTitle.render(attrs, body, t).replace('<section', '<section data-block="ptitle"')
+        const rendered = PTitle.render(attrs, body, t).replace('<section', '<section data-block="ptitle"')
+        html += wrapDirection(rendered, attrs)
       }
       i++
       continue
@@ -429,7 +471,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         i++
       }
       i++ // skip </case-flow>
-      html += CaseFlow_DA01.render(attrs, body.trim(), t)
+      html += wrapDirection(CaseFlow_DA01.render(attrs, body.trim(), t), attrs)
       continue
     }
     // 案例流（行内语法，无标签包裹时）
@@ -453,7 +495,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         i++
       }
       i++ // skip </timeline>
-      html += Timeline_DA01.render(attrs, body.trim(), t)
+      html += wrapDirection(Timeline_DA01.render(attrs, body.trim(), t), attrs)
       continue
     }
     // <slider> 标签
@@ -463,7 +505,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
       // 单行模式：<slider ...>content</slider>
       if (openMatch && openMatch[2] && /<\/slider>\s*$/.test(openMatch[2])) {
         const body = openMatch[2].replace(/<\/slider>\s*$/, '').trim()
-        html += Slider_DA01.render(attrs, body, t)
+        html += wrapDirection(Slider_DA01.render(attrs, body, t), attrs)
         i++
         continue
       }
@@ -475,7 +517,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         i++
       }
       i++ // skip </slider>
-      html += Slider_DA01.render(attrs, body.trim(), t)
+      html += wrapDirection(Slider_DA01.render(attrs, body.trim(), t), attrs)
       continue
     }
     // <engage>
@@ -483,9 +525,9 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
       const attrs = parseAttrs(line)
       // type="DA02" 使用彩色图标版，否则默认 DA01
       if (attrs.type && attrs.type.toUpperCase() === 'DA02') {
-        html += Engage_DA02.render(attrs, '', t)
+        html += wrapDirection(Engage_DA02.render(attrs, '', t), attrs)
       } else {
-        html += Engage_DA01.render(attrs, '', t)
+        html += wrapDirection(Engage_DA01.render(attrs, '', t), attrs)
       }
       i++
       continue
@@ -564,7 +606,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         const closeIdx = openMatch[2].indexOf('</mermaid>')
         if (closeIdx >= 0) {
           const body = openMatch[2].slice(0, closeIdx)
-          html += Mermaid_DA01.render(attrs, body)
+          html += wrapDirection(Mermaid_DA01.render(attrs, body), attrs)
           i++
           continue
         }
@@ -583,7 +625,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         bodyLines.push(lines[i])
         i++
       }
-      html += Mermaid_DA01.render(attrs, bodyLines.join('\n'))
+      html += wrapDirection(Mermaid_DA01.render(attrs, bodyLines.join('\n')), attrs)
       continue
     }
 
@@ -606,7 +648,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
         const body = indent + hl || '&nbsp;'
         codeInner += `<section leaf="" style="white-space:nowrap">${body}</section>`
       }
-      html += `<section data-lang="${esc(lang)}" style="white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;background:rgb(30,30,46);color:rgb(205,214,244);padding:14px 16px;border-radius:8px;margin:24px 0;font-size:12.5px;line-height:1.6;font-family:SFMono-Regular,Consolas,Monaco,monospace">${codeInner}</section>`
+      html += `<section data-lang="${esc(lang)}" dir="ltr" style="direction:ltr;text-align:left;unicode-bidi:embed;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;background:rgb(30,30,46);color:rgb(205,214,244);padding:14px 16px;border-radius:8px;margin:24px 0;font-size:12.5px;line-height:1.6;font-family:SFMono-Regular,Consolas,Monaco,monospace">${codeInner}</section>`
       continue
     }
 
@@ -699,7 +741,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
     // <chart>
     if (/^<chart\b/.test(line.trim())) {
       const attrs = parseAttrs(line.trim())
-      html += Chart_DA01.render(attrs, '', t)
+      html += wrapDirection(Chart_DA01.render(attrs, '', t), attrs)
       i++
       continue
     }
@@ -707,7 +749,7 @@ export function parseMarkdown(md: string, t: ThemeColors, formulaMap?: Map<strin
     // <img>
     if (/^<img\s/.test(line.trim())) {
       const attrs = parseAttrs(line)
-      html += Img_DA01.render(attrs, '', t)
+      html += wrapDirection(Img_DA01.render(attrs, '', t), attrs)
       i++
       continue
     }

--- a/src/views/editor/EditorPage.vue
+++ b/src/views/editor/EditorPage.vue
@@ -21,7 +21,7 @@ import {
   Save, SquareBottomDashedScissors, CheckCircle,
   Download, Copy, FileText, CircleCheck,
   Smartphone, SquarePen, CircleQuestionMark,
-  ImagePlus, Link
+  ImagePlus, Link, AlignLeft, AlignRight
 } from 'lucide-vue-next'
 import { putImage, getDataURL, cleanupImages } from '@/utils/imageDB'
 
@@ -1051,6 +1051,10 @@ function handleSaveImage() {
   previewRef.value?.saveAsImage()
 }
 
+function handleTextDirection(dir: 'ltr' | 'rtl') {
+  editorRef.value?.applyTextDirection(dir)
+}
+
 // ── 草稿业务方法 ──
 function handleOpenSaveDraft() {
   saveDraftVisible.value = true
@@ -1321,6 +1325,22 @@ onBeforeUnmount(() => {
         <!-- 桌面端：显示所有按钮 -->
         <button
           class="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 border-none rounded-md text-[13px] font-medium cursor-pointer transition-all duration-150 bg-[var(--accent-light)] text-[var(--accent)] hover:bg-[var(--accent)] hover:text-white active:scale-[0.97]"
+          title="将选中内容设为从左到右"
+          @click="handleTextDirection('ltr')"
+        >
+          <AlignLeft :size="14" />
+          LTR
+        </button>
+        <button
+          class="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 border-none rounded-md text-[13px] font-medium cursor-pointer transition-all duration-150 bg-[var(--accent-light)] text-[var(--accent)] hover:bg-[var(--accent)] hover:text-white active:scale-[0.97]"
+          title="将选中内容设为从右到左"
+          @click="handleTextDirection('rtl')"
+        >
+          <AlignRight :size="14" />
+          RTL
+        </button>
+        <button
+          class="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 border-none rounded-md text-[13px] font-medium cursor-pointer transition-all duration-150 bg-[var(--accent-light)] text-[var(--accent)] hover:bg-[var(--accent)] hover:text-white active:scale-[0.97]"
           @click="handleCopyHTML"
         >
           <Braces :size="14" />
@@ -1348,6 +1368,7 @@ onBeforeUnmount(() => {
           @copy-html="handleCopyHTML"
           @save-image="handleSaveImage"
           @copy-rich-text="handleCopyRichText"
+          @set-direction="handleTextDirection"
           @export-xhs="xhsVisible = true"
           @go-components="$router.push('/components')"
         />

--- a/src/views/editor/components/Editor.vue
+++ b/src/views/editor/components/Editor.vue
@@ -177,6 +177,57 @@ function applyInlineFormat(syntax: string, wrapType: 'delim' | 'tag' = 'delim') 
   })
 }
 
+function setOpeningTagDirection(openTag: string, dir: 'ltr' | 'rtl'): string {
+  if (/\sdir="[^"]*"/.test(openTag)) {
+    return openTag.replace(/\sdir="[^"]*"/, ` dir="${dir}"`)
+  }
+  if (/\/>$/.test(openTag)) {
+    return openTag.replace(/\s*\/>$/, ` dir="${dir}" />`)
+  }
+  return openTag.replace(/\s*>$/, ` dir="${dir}">`)
+}
+
+function applyTextDirection(dir: 'ltr' | 'rtl') {
+  if (!view) return
+  const sel = view.state.selection.main
+  if (sel.empty) {
+    const open = `<direction dir="${dir}">\n`
+    const close = '\n</direction>'
+    view.dispatch({
+      changes: { from: sel.from, to: sel.to, insert: open + close },
+      selection: { anchor: sel.from + open.length },
+    })
+    return
+  }
+
+  const selectedText = view.state.sliceDoc(sel.from, sel.to)
+  const leading = selectedText.match(/^\s*/)?.[0] || ''
+  const trailing = selectedText.match(/\s*$/)?.[0] || ''
+  const core = selectedText.slice(leading.length, selectedText.length - trailing.length)
+  const openMatch = core.match(/^<(\w[\w-]*)([^>]*)>/s)
+
+  if (openMatch && (openMatch[1] === 'direction' || openMatch[1] in tagMap)) {
+    const updated = core.replace(openMatch[0], setOpeningTagDirection(openMatch[0], dir))
+    const insert = leading + updated + trailing
+    view.dispatch({
+      changes: { from: sel.from, to: sel.to, insert },
+      selection: { anchor: sel.from, head: sel.from + insert.length },
+    })
+    return
+  }
+
+  const open = `<direction dir="${dir}">\n`
+  const close = '\n</direction>'
+  const insert = open + selectedText + close
+  view.dispatch({
+    changes: { from: sel.from, to: sel.to, insert },
+    selection: {
+      anchor: sel.from + open.length,
+      head: sel.from + open.length + selectedText.length,
+    },
+  })
+}
+
 // ── 标签选中检测 ──
 const tagRegex = /^<(\w[\w-]*)((?:\s+[^>]*?)?)(\/?)>/s
 let lastTagSelection: {
@@ -573,7 +624,7 @@ function insertAtCursor(text: string) {
   })
 }
 
-defineExpose({ scrollTo, replaceRange, insertAtCursor, isAtLineStart, hasInlineSelection, isInsideTag, applyInlineFormat })
+defineExpose({ scrollTo, replaceRange, insertAtCursor, isAtLineStart, hasInlineSelection, isInsideTag, applyInlineFormat, applyTextDirection })
 </script>
 
 <template>

--- a/src/views/editor/components/mobile/MobileActionsMenu.vue
+++ b/src/views/editor/components/mobile/MobileActionsMenu.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onBeforeUnmount } from 'vue'
 import { useDropdownGroup } from '@/composables/useDropdownGroup'
-import { Braces, Copy, Download, EllipsisVertical, FileText, Image, LayoutGrid, Sparkles } from 'lucide-vue-next'
+import { AlignLeft, AlignRight, Braces, Copy, Download, EllipsisVertical, FileText, Image, LayoutGrid, Sparkles } from 'lucide-vue-next'
 
 const props = defineProps<{
   mode?: 'editor' | 'preview'
@@ -15,6 +15,7 @@ const emit = defineEmits<{
   'copy-rich-text': []
   'export-xhs': []
   'go-components': []
+  'set-direction': [dir: 'ltr' | 'rtl']
 }>()
 
 const { toggle: groupToggle, isVisible } = useDropdownGroup('actions')
@@ -65,6 +66,20 @@ onBeforeUnmount(() => {
         >
           <LayoutGrid :size="14" />
           扩展组件
+        </button>
+        <button
+          class="mobile-action-option w-full flex items-center gap-2 px-3 py-2 rounded-lg border-none bg-transparent cursor-pointer text-[13px] text-black/80 transition-colors duration-150 hover:bg-black/5"
+          @click="handleAction(() => emit('set-direction', 'ltr'))"
+        >
+          <AlignLeft :size="14" />
+          选区 LTR
+        </button>
+        <button
+          class="mobile-action-option w-full flex items-center gap-2 px-3 py-2 rounded-lg border-none bg-transparent cursor-pointer text-[13px] text-black/80 transition-colors duration-150 hover:bg-black/5"
+          @click="handleAction(() => emit('set-direction', 'rtl'))"
+        >
+          <AlignRight :size="14" />
+          选区 RTL
         </button>
         <a
           href="https://chat.deepseek.com/share/f6bhvloktj8wdl5fie"


### PR DESCRIPTION
## Summary

This adds explicit RTL/LTR direction formatting support to the editor and renderer.

Users can:

- add `dir="rtl"` or `dir="ltr"` directly to existing extension tags, for example:
  `<title dir="rtl" ...>...</title>`
  `<p-title dir="rtl" ...></p-title>`
- wrap ordinary Markdown content with:
  `<direction dir="rtl">...</direction>`
- use new toolbar actions to apply LTR/RTL formatting to the current selection.

The implementation keeps direction as visible Markdown content instead of a global preview-only switch, so one article can mix RTL and LTR sections.

## Details

- Extension tags with `dir` / `direction` are wrapped in an inline-styled direction container.
- Ordinary selected Markdown is wrapped in `<direction dir="...">`.
- Code blocks remain `ltr` inside RTL containers for readability.
- Existing extension renderers are not modified.

## Validation

Full local build is currently blocked on the v0.2.8 baseline when private/fallback modules are unavailable:

- `vue-tsc -b` cannot resolve `@/extension/...`
- `vite build` cannot load fallback `src/views/help/TutorialList.vue`

Local targeted checks passed:

- bundled `src/utils/markdownParser.ts` with Vite-compatible aliases
- compiled affected Vue SFC scripts/templates
- verified parser output for `<direction dir="rtl">` and extension tags with `dir="rtl"`